### PR TITLE
fix(api): restore Edge proxy routes

### DIFF
--- a/scripts/smoke-edge.mjs
+++ b/scripts/smoke-edge.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+// Purpose: Smoke test script for Next.js API proxies to Edge Functions.
+// Called by: Developers to verify integration before deployment.
+// Usage: node scripts/smoke-edge.mjs
+
+const BASE_URL = 'http://localhost:3000';
+
+async function testEndpoint(endpoint, payload, description) {
+  console.log(`\n🧪 Testing ${description}...`);
+  
+  try {
+    const response = await fetch(`${BASE_URL}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    
+    const data = await response.json();
+    
+    if (response.ok) {
+      console.log(`✅ ${description}: Success (${response.status})`);
+      console.log(`   Response:`, JSON.stringify(data, null, 2));
+    } else {
+      console.log(`❌ ${description}: Failed (${response.status})`);
+      console.log(`   Error:`, data);
+    }
+    
+    return response.ok;
+  } catch (error) {
+    console.log(`❌ ${description}: Network error`);
+    console.log(`   Error:`, error.message);
+    return false;
+  }
+}
+
+async function runSmokeTests() {
+  console.log('🚀 Starting Edge Function Integration Smoke Tests\n');
+  
+  const tests = [
+    {
+      endpoint: '/api/profile-address',
+      payload: { email: 'test@example.com', address: '123 Main St, City, State 12345' },
+      description: 'Profile Address API'
+    },
+    {
+      endpoint: '/api/subscriptions-toggle',
+      payload: { email: 'test@example.com', action: 'unsubscribe' },
+      description: 'Subscriptions Toggle API'
+    },
+    {
+      endpoint: '/api/unsubscribe',
+      payload: { token: 'test-token-123', list_key: 'general' },
+      description: 'Unsubscribe API'
+    }
+  ];
+  
+  let passed = 0;
+  let total = tests.length;
+  
+  for (const test of tests) {
+    const success = await testEndpoint(test.endpoint, test.payload, test.description);
+    if (success) passed++;
+  }
+  
+  console.log(`\n📊 Test Results: ${passed}/${total} passed`);
+  
+  if (passed === total) {
+    console.log('🎉 All tests passed! Edge Function integration is working.');
+    process.exit(0);
+  } else {
+    console.log('⚠️  Some tests failed. Check the logs above for details.');
+    process.exit(1);
+  }
+}
+
+// Run tests if this script is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runSmokeTests().catch(console.error);
+}

--- a/src/app/api/profile-address/route.ts
+++ b/src/app/api/profile-address/route.ts
@@ -1,0 +1,51 @@
+// Purpose: Next.js API route proxy for profile-address Edge Function.
+// Called by: Signup form to enrich address and create profile.
+// Security: Validates input with Zod, calls Edge Function with shared secret.
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { callEdge, generateRequestId, createErrorResponse, createSuccessResponse } from '@/lib/edge';
+
+const profileAddressSchema = z.object({
+  email: z.string().email(),
+  address: z.string().min(10),
+  name: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validatedData = profileAddressSchema.parse(body);
+    
+    const requestId = generateRequestId();
+    const response = await callEdge('profile-address', validatedData, requestId);
+    
+    if (!response.ok) {
+      const errorData = await response.json();
+      return createErrorResponse(
+        errorData.message || 'Profile address update failed',
+        errorData.code || 'EDGE_FUNCTION_ERROR',
+        response.status
+      );
+    }
+    
+    const result = await response.json();
+    return createSuccessResponse(result.data);
+    
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createErrorResponse(
+        'Invalid input data',
+        'VALIDATION_ERROR',
+        400
+      );
+    }
+    
+    console.error('Profile address API error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      'INTERNAL_ERROR',
+      500
+    );
+  }
+}

--- a/src/app/api/subscriptions-toggle/route.ts
+++ b/src/app/api/subscriptions-toggle/route.ts
@@ -1,0 +1,51 @@
+// Purpose: Next.js API route proxy for subscriptions-toggle Edge Function.
+// Called by: Preferences page to toggle subscription status.
+// Security: Validates input with Zod, calls Edge Function with shared secret.
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { callEdge, generateRequestId, createErrorResponse, createSuccessResponse } from '@/lib/edge';
+
+const subscriptionToggleSchema = z.object({
+  email: z.string().email(),
+  list_key: z.string().default('general'),
+  action: z.enum(['subscribe', 'unsubscribe']),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validatedData = subscriptionToggleSchema.parse(body);
+    
+    const requestId = generateRequestId();
+    const response = await callEdge('subscriptions-toggle', validatedData, requestId);
+    
+    if (!response.ok) {
+      const errorData = await response.json();
+      return createErrorResponse(
+        errorData.message || 'Subscription toggle failed',
+        errorData.code || 'EDGE_FUNCTION_ERROR',
+        response.status
+      );
+    }
+    
+    const result = await response.json();
+    return createSuccessResponse(result.data);
+    
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createErrorResponse(
+        'Invalid input data',
+        'VALIDATION_ERROR',
+        400
+      );
+    }
+    
+    console.error('Subscription toggle API error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      'INTERNAL_ERROR',
+      500
+    );
+  }
+}

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,0 +1,50 @@
+// Purpose: Next.js API route proxy for unsubscribe Edge Function.
+// Called by: Unsubscribe page to securely unsubscribe users.
+// Security: Validates HMAC token, calls Edge Function with shared secret.
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { callEdge, generateRequestId, createErrorResponse, createSuccessResponse } from '@/lib/edge';
+
+const unsubscribeSchema = z.object({
+  token: z.string().min(1),
+  list_key: z.string().default('general'),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validatedData = unsubscribeSchema.parse(body);
+    
+    const requestId = generateRequestId();
+    const response = await callEdge('unsubscribe', validatedData, requestId);
+    
+    if (!response.ok) {
+      const errorData = await response.json();
+      return createErrorResponse(
+        errorData.message || 'Unsubscribe failed',
+        errorData.code || 'EDGE_FUNCTION_ERROR',
+        response.status
+      );
+    }
+    
+    const result = await response.json();
+    return createSuccessResponse(result.data);
+    
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return createErrorResponse(
+        'Invalid input data',
+        'VALIDATION_ERROR',
+        400
+      );
+    }
+    
+    console.error('Unsubscribe API error:', error);
+    return createErrorResponse(
+      'Internal server error',
+      'INTERNAL_ERROR',
+      500
+    );
+  }
+}

--- a/src/lib/edge.ts
+++ b/src/lib/edge.ts
@@ -1,0 +1,52 @@
+// Purpose: Shared helper for Next.js API routes to call Supabase Edge Functions securely.
+// Called by: API routes that need to proxy requests to Edge Functions.
+// Security: Uses x-edge-secret header for authentication between Next.js and Edge Functions.
+
+const edgeBaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace('.supabase.co', '.supabase.co/functions/v1');
+
+export function generateRequestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export async function callEdge(
+  functionName: string, 
+  body: any, 
+  requestId: string
+): Promise<Response> {
+  if (!edgeBaseUrl) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL not configured');
+  }
+
+  const url = `${edgeBaseUrl}/${functionName}`;
+  
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-edge-secret': process.env.EDGE_SHARED_SECRET || '',
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify(body),
+    });
+
+    return response;
+  } catch (error) {
+    console.error(`Edge function ${functionName} call failed:`, error);
+    throw new Error(`Failed to call edge function: ${error}`);
+  }
+}
+
+export function createErrorResponse(message: string, code: string = 'INTERNAL_ERROR', status: number = 500) {
+  return Response.json(
+    { ok: false, code, message, details: null },
+    { status }
+  );
+}
+
+export function createSuccessResponse(data: any, status: number = 200) {
+  return Response.json(
+    { ok: true, data },
+    { status }
+  );
+}


### PR DESCRIPTION
Restores Next.js API routes that call Supabase Edge functions:
- /api/profile-address
- /api/subscriptions-toggle
- /api/unsubscribe

No rewrites; pulled from origin/wip/local-main-ahead. After merge, redeploy main and re-run smoke tests.