### PR TITLE
chore(verify): add post-merge edge verification script and doc

### DIFF
--- a/docs/functional/post_merge_edge_validation.md
+++ b/docs/functional/post_merge_edge_validation.md
@@ -1,0 +1,175 @@
+# Post-Merge Edge Function Validation Guide
+
+## Overview
+
+This document describes how to validate that Edge Function authentication is working correctly after merging the authentication implementation PR.
+
+## Quick Start
+
+### 1. Set Environment Variables
+
+```bash
+# Required: Your Edge Function shared secret
+export EDGE_SHARED_SECRET="your-secret-here"
+
+# Optional: Override defaults
+export BASE_URL="https://your-domain.vercel.app"
+export FN_BASE="https://your-project.functions.supabase.co"
+```
+
+### 2. Run Verification
+
+```bash
+pnpm edge:verify
+```
+
+## What Gets Tested
+
+### Next.js API Routes (Client Perspective)
+- **POST** `/api/profile-address` - Should work without client secrets
+- **POST** `/api/subscriptions-toggle` - Should work without client secrets  
+- **GET** `/api/unsubscribe` - Should work without client secrets
+
+### Direct Edge Function Calls (Server-to-Server)
+- **POST** `/profile-address` - Requires `x-edge-secret` header
+- **POST** `/subscriptions-toggle` - Requires `x-edge-secret` header
+- **GET** `/unsubscribe` - Requires `x-edge-secret` header
+
+## Acceptance Criteria
+
+### ✅ Success Conditions
+
+#### Next.js API Routes
+- **Status**: 200 (or appropriate success code)
+- **Behavior**: Work without any secret from client
+- **Security**: Next.js server forwards `x-edge-secret` header internally
+
+#### Direct Edge Function Calls
+- **Without Header**: 401 "Missing or invalid authorization header"
+- **With Valid Header**: 200 (or appropriate success code)
+- **Authentication**: Properly validates `x-edge-secret` header
+
+### ❌ Failure Indicators
+
+#### 401 Unauthorized
+- **Cause**: Missing or invalid `x-edge-secret` header
+- **Action**: Verify `EDGE_SHARED_SECRET` environment variable is set correctly
+
+#### 404 Not Found
+- **Cause**: Edge Function not deployed or wrong URL
+- **Action**: Deploy Edge Functions to Supabase
+
+#### 500 Internal Server Error
+- **Cause**: Edge Function configuration issue
+- **Action**: Check Supabase function logs and environment variables
+
+## Troubleshooting Matrix
+
+| Status | Next.js API | Direct Edge Function | Likely Cause | Action |
+|--------|-------------|---------------------|--------------|---------|
+| 200 | ✅ | ✅ | All working | None needed |
+| 401 | ✅ | ❌ | Edge Function auth issue | Check `EDGE_SHARED_SECRET` |
+| 404 | ❌ | ❌ | Functions not deployed | Deploy to Supabase |
+| 500 | ❌ | ❌ | Configuration error | Check Supabase logs |
+
+## Detailed Test Scenarios
+
+### Scenario 1: Full Authentication Working
+```
+✅ Next.js API routes: 3/3 endpoints working
+✅ Direct Edge Functions: 6/6 endpoints working
+✅ Authentication: 3/3 no-header requests properly rejected (401)
+✅ Authentication: 3/3 with-header requests succeeded
+```
+
+### Scenario 2: Partial Authentication Working
+```
+✅ Next.js API routes: 3/3 endpoints working
+⚠️  Direct Edge Functions: 3/6 endpoints working
+❌ Authentication: Some requests not properly rejected
+```
+
+### Scenario 3: Authentication Broken
+```
+❌ Next.js API routes: 0/3 endpoints working
+❌ Direct Edge Functions: 0/6 endpoints working
+❌ Authentication: All requests failing
+```
+
+## Environment Variable Reference
+
+| Variable | Default | Purpose | Required |
+|----------|---------|---------|----------|
+| `EDGE_SHARED_SECRET` | None | Secret for Edge Function auth | Yes (for full testing) |
+| `BASE_URL` | `https://yff-web.vercel.app` | Next.js app URL | No |
+| `FN_BASE` | `https://zeypnacddltdtedqxhix.functions.supabase.co` | Supabase functions URL | No |
+
+## Deployment Checklist
+
+After merging the authentication PR:
+
+1. **Deploy Edge Functions** to Supabase:
+   ```bash
+   supabase functions deploy profile-address --project-ref zeypnacddltdtedqxhix
+   supabase functions deploy subscriptions-toggle --project-ref zeypnacddltdtedqxhix
+   supabase functions deploy unsubscribe --project-ref zeypnacddltdtedqxhix
+   ```
+
+2. **Verify Environment Variables**:
+   - `EDGE_SHARED_SECRET` set in Supabase (functions)
+   - `EDGE_SHARED_SECRET` set in Vercel (production)
+
+3. **Run Verification Script**:
+   ```bash
+   export EDGE_SHARED_SECRET="your-secret"
+   pnpm edge:verify
+   ```
+
+4. **Check Results**:
+   - All Next.js API routes return 200
+   - Direct Edge Function calls return 401 without header
+   - Direct Edge Function calls return 200 with valid header
+
+## Common Issues and Solutions
+
+### Issue: "EDGE_SHARED_SECRET not set"
+**Solution**: Set the environment variable before running the script
+
+### Issue: "Request failed: fetch"
+**Solution**: Check network connectivity and URL accessibility
+
+### Issue: "Could not read response body"
+**Solution**: Response may be malformed; check Edge Function logs
+
+### Issue: All tests returning 401
+**Solution**: Verify the secret value matches between Supabase and Vercel
+
+## Integration with CI/CD
+
+The verification script can be integrated into CI/CD pipelines:
+
+```yaml
+# Example GitHub Actions step
+- name: Verify Edge Function Authentication
+  run: |
+    export EDGE_SHARED_SECRET="${{ secrets.EDGE_SHARED_SECRET }}"
+    export BASE_URL="${{ secrets.BASE_URL }}"
+    export FN_BASE="${{ secrets.FN_BASE }}"
+    pnpm edge:verify
+```
+
+## Security Notes
+
+- **Never log the actual secret value** - the script shows `[SET]` or `[NOT SET]`
+- **Use environment variables** - don't hardcode secrets in scripts
+- **Test in staging first** - verify authentication before production deployment
+- **Monitor logs** - watch for authentication failures in production
+
+## Support
+
+If verification fails and you need assistance:
+
+1. **Check the troubleshooting matrix** above
+2. **Review Supabase function logs** for detailed error information
+3. **Verify environment variables** are set correctly
+4. **Test with minimal payloads** to isolate the issue

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "build:dict": "node scripts/build-data-dictionary.js",
-    "smoke:edge": "node scripts/smoke-edge.mjs"
+    "smoke:edge": "node scripts/smoke-edge.mjs",
+    "edge:verify": "node scripts/edge-verify.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/scripts/edge-verify.mjs
+++ b/scripts/edge-verify.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+/**
+ * Edge Function Authentication Verification Script
+ * 
+ * Purpose: Verify that Edge Function authentication works end-to-end after deployment
+ * Called by: Developers and CI to validate authentication implementation
+ * 
+ * Tests:
+ * 1. Next.js API routes (should work without client secrets)
+ * 2. Direct Edge Function calls (should require x-edge-secret header)
+ */
+
+// Environment configuration
+const BASE_URL = process.env.BASE_URL || 'https://yff-web.vercel.app';
+const FN_BASE = process.env.FN_BASE || 'https://zeypnacddltdtedqxhix.functions.supabase.co';
+const EDGE_SHARED_SECRET = process.env.EDGE_SHARED_SECRET;
+
+console.log('🔐 Edge Function Authentication Verification');
+console.log('==========================================');
+console.log(`Base URL: ${BASE_URL}`);
+console.log(`Function Base: ${FN_BASE}`);
+console.log(`EDGE_SHARED_SECRET: ${EDGE_SHARED_SECRET ? '[SET]' : '[NOT SET]'}`);
+console.log('');
+
+// Test results tracking
+const results = {
+  nextjs: {},
+  direct: {}
+};
+
+// Helper function to make HTTP requests and capture results
+async function testEndpoint(name, url, options = {}) {
+  try {
+    const start = Date.now();
+    const response = await fetch(url, options);
+    const duration = Date.now() - start;
+    
+    let body = '';
+    try {
+      body = await response.text();
+    } catch (e) {
+      body = '[Could not read response body]';
+    }
+    
+    const status = response.status;
+    const bodyPreview = body.length > 200 ? body.substring(0, 200) + '...' : body;
+    
+    return {
+      name,
+      url,
+      status,
+      duration,
+      bodyPreview,
+      success: status >= 200 && status < 300
+    };
+  } catch (error) {
+    return {
+      name,
+      url,
+      status: 'ERROR',
+      duration: 0,
+      bodyPreview: `Request failed: ${error.message}`,
+      success: false
+    };
+  }
+}
+
+// Test Next.js API routes (no secret required from client)
+async function testNextJsRoutes() {
+  console.log('🧪 Testing Next.js API Routes (should work without client secrets)');
+  console.log('----------------------------------------------------------------');
+  
+  const tests = [
+    {
+      name: 'POST /api/profile-address',
+      url: `${BASE_URL}/api/profile-address`,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          address: '123 Main St, Upper Arlington, OH 43221'
+        })
+      }
+    },
+    {
+      name: 'POST /api/subscriptions-toggle',
+      url: `${BASE_URL}/api/subscriptions-toggle`,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          list_key: 'general',
+          action: 'subscribe'
+        })
+      }
+    },
+    {
+      name: 'GET /api/unsubscribe',
+      url: `${BASE_URL}/api/unsubscribe?token=fake&email=qa+verify@example.com&list_key=general`,
+      options: {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+      }
+    }
+  ];
+  
+  for (const test of tests) {
+    const result = await testEndpoint(test.name, test.url, test.options);
+    results.nextjs[test.name] = result;
+    
+    const status = result.status;
+    const icon = result.success ? '✅' : '❌';
+    console.log(`${icon} ${test.name}: ${status} (${result.duration}ms)`);
+    console.log(`   Body: ${result.bodyPreview}`);
+    console.log('');
+  }
+}
+
+// Test direct Edge Function calls (should require x-edge-secret header)
+async function testDirectEdgeFunctions() {
+  if (!EDGE_SHARED_SECRET) {
+    console.log('⏭️  Skipping direct Edge Function tests: EDGE_SHARED_SECRET not set');
+    console.log('');
+    return;
+  }
+  
+  console.log('🔒 Testing Direct Edge Function Calls (should require x-edge-secret header)');
+  console.log('------------------------------------------------------------------------');
+  
+  const tests = [
+    {
+      name: 'POST /profile-address (no header)',
+      url: `${FN_BASE}/profile-address`,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          address: '123 Main St, Upper Arlington, OH 43221'
+        })
+      }
+    },
+    {
+      name: 'POST /profile-address (with header)',
+      url: `${FN_BASE}/profile-address`,
+      options: {
+        method: 'POST',
+        headers: { 
+          'Content-Type': 'application/json',
+          'x-edge-secret': EDGE_SHARED_SECRET
+        },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          address: '123 Main St, Upper Arlington, OH 43221'
+        })
+      }
+    },
+    {
+      name: 'POST /subscriptions-toggle (no header)',
+      url: `${FN_BASE}/subscriptions-toggle`,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          list_key: 'general',
+          action: 'subscribe'
+        })
+      }
+    },
+    {
+      name: 'POST /subscriptions-toggle (with header)',
+      url: `${FN_BASE}/subscriptions-toggle`,
+      options: {
+        method: 'POST',
+        headers: { 
+          'Content-Type': 'application/json',
+          'x-edge-secret': EDGE_SHARED_SECRET
+        },
+        body: JSON.stringify({
+          email: 'qa+verify@example.com',
+          list_key: 'general',
+          action: 'subscribe'
+        })
+      }
+    },
+    {
+      name: 'GET /unsubscribe (no header)',
+      url: `${FN_BASE}/unsubscribe?token=fake&email=qa+verify@example.com&list_key=general`,
+      options: {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+      }
+    },
+    {
+      name: 'GET /unsubscribe (with header)',
+      url: `${FN_BASE}/unsubscribe?token=fake&email=qa+verify@example.com&list_key=general`,
+      options: {
+        method: 'GET',
+        headers: { 
+          'Content-Type': 'application/json',
+          'x-edge-secret': EDGE_SHARED_SECRET
+        }
+      }
+    }
+  ];
+  
+  for (const test of tests) {
+    const result = await testEndpoint(test.name, test.url, test.options);
+    results.direct[test.name] = result;
+    
+    const status = result.status;
+    const icon = result.success ? '✅' : '❌';
+    console.log(`${icon} ${test.name}: ${status} (${result.duration}ms)`);
+    console.log(`   Body: ${result.bodyPreview}`);
+    console.log('');
+  }
+}
+
+// Generate summary report
+function generateSummary() {
+  console.log('📊 Test Summary');
+  console.log('===============');
+  
+  // Next.js API routes summary
+  console.log('\n🌐 Next.js API Routes:');
+  const nextjsResults = Object.values(results.nextjs);
+  const nextjsPass = nextjsResults.filter(r => r.success).length;
+  const nextjsTotal = nextjsResults.length;
+  console.log(`   ${nextjsPass}/${nextjsTotal} endpoints working`);
+  
+  // Direct Edge Function summary
+  if (EDGE_SHARED_SECRET) {
+    console.log('\n🔒 Direct Edge Functions:');
+    const directResults = Object.values(results.direct);
+    const directPass = directResults.filter(r => r.success).length;
+    const directTotal = directResults.length;
+    console.log(`   ${directPass}/${directTotal} endpoints working`);
+    
+    // Check authentication behavior
+    const noHeaderTests = directResults.filter(r => r.name.includes('(no header)'));
+    const withHeaderTests = directResults.filter(r => r.name.includes('(with header)'));
+    
+    const noHeader401 = noHeaderTests.filter(r => r.status === 401).length;
+    const withHeaderSuccess = withHeaderTests.filter(r => r.success).length;
+    
+    console.log(`   Authentication: ${noHeader401}/${noHeaderTests.length} no-header requests properly rejected (401)`);
+    console.log(`   Authentication: ${withHeaderSuccess}/${withHeaderTests.length} with-header requests succeeded`);
+  } else {
+    console.log('\n⏭️  Direct Edge Functions: Skipped (EDGE_SHARED_SECRET not set)');
+  }
+  
+  // Overall assessment
+  console.log('\n🎯 Overall Assessment:');
+  const allResults = [...Object.values(results.nextjs), ...Object.values(results.direct)];
+  const totalPass = allResults.filter(r => r.success).length;
+  const totalTests = allResults.length;
+  
+  if (totalPass === totalTests) {
+    console.log('   ✅ ALL TESTS PASSED - Edge Function authentication working correctly!');
+  } else {
+    console.log(`   ⚠️  ${totalPass}/${totalTests} tests passed - Some issues detected`);
+    
+    // Identify specific failures
+    const failures = allResults.filter(r => !r.success);
+    if (failures.length > 0) {
+      console.log('\n   🔍 Failed Tests:');
+      failures.forEach(f => {
+        console.log(`      ❌ ${f.name}: ${f.status} - ${f.bodyPreview}`);
+      });
+    }
+  }
+}
+
+// Main execution
+async function main() {
+  try {
+    await testNextJsRoutes();
+    await testDirectEdgeFunctions();
+    generateSummary();
+    
+    // Exit with appropriate code
+    const allResults = [...Object.values(results.nextjs), ...Object.values(results.direct)];
+    const allPassed = allResults.every(r => r.success);
+    process.exit(allPassed ? 0 : 1);
+    
+  } catch (error) {
+    console.error('❌ Verification script failed:', error);
+    process.exit(1);
+  }
+}
+
+// Run if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
- Add comprehensive edge-verify.mjs script for testing Edge Function authentication
- Test Next.js API routes (should work without client secrets)
- Test direct Edge Function calls (should require x-edge-secret header)
- Add edge:verify script to package.json for easy access
- Create detailed documentation with troubleshooting matrix and deployment checklist
- Script never logs secret values, only shows [SET] or [NOT SET]
- Comprehensive reporting with status codes, response times, and body previews