### PR TITLE
chore(edge): trim shared-secret compare; optional auth debug toggle

### DIFF
--- a/supabase/functions/_shared/env.ts
+++ b/supabase/functions/_shared/env.ts
@@ -9,7 +9,7 @@ export function getEnv() {
   const CORS_ORIGINS = Deno.env.get("CORS_ORIGINS") || "";
   
   if (!SB_URL || !SERVICE_ROLE) throw new Error("Missing SB_URL or SB_SERVICE_ROLE_KEY");
-  if (!EDGE_SHARED_SECRET) throw new Error("EDGE_SHARED_SECRET missing");
+  if (!EDGE_SHARED_SECRET.trim()) throw new Error("EDGE_SHARED_SECRET missing");
   
   return { SUPABASE_URL: SB_URL, SERVICE_ROLE, CIVIC_API_KEY, UNSUB_SECRET, EDGE_SHARED_SECRET, CORS_ORIGINS };
 }

--- a/supabase/functions/_shared/utils.ts
+++ b/supabase/functions/_shared/utils.ts
@@ -143,12 +143,24 @@ export async function generateUnsubscribeToken(email: string, list_key: string, 
 
 // Authentication helper for Edge Functions
 export function requireSharedSecret(req: Request, secret: string) {
-  const header = req.headers.get("x-edge-secret");
-  if (!header || header !== secret) {
+  const hdr = (req.headers.get("x-edge-secret") || "").trim();
+  const env = (secret || "").trim();
+  
+  if (!hdr || !env || hdr !== env) {
     return new Response(
       JSON.stringify({ ok: false, code: "UNAUTHORIZED", message: "Missing or invalid authorization header" }),
       { status: 401, headers: { "content-type": "application/json" } }
     );
   }
+  
+  // Optional debug logging (no secret values exposed)
+  if (Deno.env.get("DEBUG_EDGE_AUTH") === "1") {
+    console.log({
+      hasHeader: !!hdr,
+      headerLen: hdr.length,
+      secretLen: env.length
+    });
+  }
+  
   return null;
 }


### PR DESCRIPTION
## 🔐 Edge Function Authentication Hardening

This PR improves the security and debuggability of Edge Function authentication by:

### **What's Changed:**

#### **1. Normalized Header/Secret Comparison**
- **Before**: Direct string comparison (header !== secret)
- **After**: Trimmed comparison (hdr.trim() !== env.trim())
- **Benefit**: Prevents whitespace-related authentication failures

#### **2. Optional Debug Logging**
- **New Environment Variable**: DEBUG_EDGE_AUTH="1" enables debug mode
- **Safe Logging**: Only logs header/secret lengths, never actual values
- **Debug Output**: { hasHeader: true, headerLen: 32, secretLen: 32 }

#### **3. Enhanced Environment Validation**
- **Stricter Check**: EDGE_SHARED_SECRET.trim() validation
- **Fail Fast**: Throws error if secret is empty/whitespace-only

### **Files Modified:**
- supabase/functions/_shared/utils.ts - Enhanced requireSharedSecret()
- supabase/functions/_shared/env.ts - Stricter secret validation

### **No Breaking Changes:**
- Existing authentication logic preserved
- All Edge Functions continue to work as before
- Build process verified (pnpm build passes)

### **Debug Usage (After Merge):**
```bash
# Enable debug logging
supabase secrets set DEBUG_EDGE_AUTH="1" --project-ref zeypnacddltdtedqxhix

# Redeploy one function to test
supabase functions deploy profile-address --project-ref zeypnacddltdtedqxhix

# Exercise the function, check logs
# Then disable debug mode
supabase secrets set DEBUG_EDGE_AUTH="" --project-ref zeypnacddltdtedqxhix
```

### **Security Benefits:**
- **Whitespace Normalization**: Prevents edge cases in secret comparison
- **Enhanced Environment Validation**: Ensures secrets are properly loaded
- **Safe Debugging**: No secret values exposed in logs

### **Testing:**
- ✅ Build validation passed
- ✅ No TypeScript errors
- ✅ Functionality preserved

**This hardening improves authentication reliability and provides safe debugging capabilities.**