### PR TITLE
feat/allowlist test auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This repo sends **personalized civic newsletters**. Editors write **one article*
 - ZIP Explainer: `ZIP_Personalization_Explainer.md`
 - ZIP Step-by-Step: `ZIP_Personalization_Step_by_Step.md`
 
+## Runbooks
+- Incident triage: `docs/runbooks/incident-triage.md`
+
 ## Migrations & Policies
 - Schema migration (idempotent): `schema_migration_v2_1.sql`
 - DB Migration Checklist: `db_migration_checklist.md`

--- a/docs/runbooks/incident-triage.md
+++ b/docs/runbooks/incident-triage.md
@@ -1,0 +1,60 @@
+### Incident Triage Runbook
+
+Purpose: Fast, copy/paste checks to confirm service health, auth flows, and trace issues using requestId.
+
+Prereqs
+- Replace BASE with your environment URL (dev, preview, prod)
+- Use a fresh shell (no cookies) for unauth checks
+
+Health
+```bash
+BASE="https://yff-qrdnutwzl-kevinjmireles-projects.vercel.app" # prod
+curl -s -i "$BASE/api/health" | sed -n '1,20p'
+```
+Expect: HTTP 200, JSON { ok:true }
+
+Admin UI (unauth)
+```bash
+curl -s -i "$BASE/admin/send" | sed -n '1,20p'
+```
+Expect: 302/307 redirect to /admin/login. Header should include X-Request-Id.
+
+Admin API (unauth)
+```bash
+curl -s -i -X POST "$BASE/api/send/start" -H 'content-type: application/json' -d '{}' | sed -n '1,60p'
+```
+Expect: 401 JSON { ok:false, code:"UNAUTHORIZED", message, requestId? }. Header includes X-Request-Id.
+
+Invalid Login
+```bash
+curl -s -i -X POST "$BASE/api/admin/login" -H 'content-type: application/json' -d '{"password":"bad"}' | sed -n '1,60p'
+```
+Expect: 401 JSON { code:"INVALID_PASSWORD", message, requestId? }
+
+Valid Login + Authenticated API
+```bash
+curl -s -c /tmp/c -b /tmp/c -X POST "$BASE/api/admin/login" -H 'content-type: application/json' -d '{"password":"<ADMIN_PASSWORD>"}' | sed -n '1,40p'
+
+curl -s -i -b /tmp/c -X POST "$BASE/api/send/start" -H 'content-type: application/json' -d '{"dataset_id":"00000000-0000-0000-0000-000000000000"}' | sed -n '1,80p'
+```
+Expect: Non-401. If dataset is bogus, 404 JSON { code:"DATASET_NOT_FOUND", message, requestId? }
+
+Manual requestId test
+```bash
+curl -s -i -X POST "$BASE/api/send/start" \
+  -H 'content-type: application/json' \
+  -H 'X-Request-Id: triage-123' \
+  -d '{}' | sed -n '1,80p'
+```
+Expect: Body has requestId:"triage-123"; header may include X-Request-Id (from middleware in preview/prod).
+
+Common Causes and Fixes
+- 401 on Admin APIs (unauth): Login flow or cookie missing. Re-login, ensure yff_admin cookie present (HttpOnly, Secure, SameSite=Lax).
+- 307/302 on APIs: Middleware matcher too broad. Our matcher excludes APIs; if seen, confirm production deploy is current.
+- Stale page (x-nextjs-prerender: 1): Ensure admin pages are dynamic (`dynamic='force-dynamic'`, `revalidate=0`).
+- 403 from Vercel: Security Checkpoint blocking scripted requests. Test via browser; allowlist IP/UA for CI.
+
+When escalating
+- Capture: endpoint, status, full headers, body, and requestId.
+- Search logs by requestId in Vercel to correlate events.
+- Include last merged commit (check X-Commit at "/").

--- a/middleware.ts
+++ b/middleware.ts
@@ -43,7 +43,7 @@ export default function middleware(req: NextRequest) {
   const isProd = process.env.VERCEL_ENV === 'production' || process.env.NODE_ENV === 'production';
   const testAccessRequired = process.env.TEST_ACCESS_TOKEN || '';
 
-  // Allowlist helper and health endpoints
+  // Allowlist helper and health endpoints (enables setting test_access cookie in prod)
   const isHelperRoute = pathname.startsWith('/api/test-auth') || pathname.startsWith('/api/echo-ip') || pathname.startsWith('/api/health');
   if (!(enforceProdOnly && isProd) || isHelperRoute) {
     // Skip enforcement (not prod or helper/health)

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,13 +2,62 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export const config = {
-  matcher: ['/admin/:path*', '/api/admin/:path*', '/api/send/:path*'],
+  // Protect admin UI and all APIs so we can enforce test-access gate in prod
+  matcher: ['/admin/:path*', '/api/:path*'],
 };
 
 export default function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const existingReqId = req.headers.get('x-request-id') || req.headers.get('x-correlation-id');
   const requestId = existingReqId || crypto.randomUUID();
+
+  // ---------- Test Access Gate (prod-only by default) ----------
+  // Allow assets and Next internals quickly
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/public') ||
+    pathname.startsWith('/assets')
+  ) {
+    const res = NextResponse.next();
+    res.headers.set('X-Request-Id', requestId);
+    return res;
+  }
+
+  // Only guard our matchers; early return otherwise (defensive)
+  const isProtected = pathname.startsWith('/admin') || pathname.startsWith('/api');
+  if (!isProtected) {
+    const res = NextResponse.next();
+    res.headers.set('X-Request-Id', requestId);
+    return res;
+  }
+
+  if (req.method === 'OPTIONS') {
+    const res = NextResponse.next();
+    res.headers.set('X-Request-Id', requestId);
+    return res;
+  }
+
+  // Do not enforce outside production when enabled
+  const enforceProdOnly = (process.env.TEST_ACCESS_ENFORCE_PROD_ONLY ?? 'true') === 'true';
+  const isProd = process.env.VERCEL_ENV === 'production' || process.env.NODE_ENV === 'production';
+  const testAccessRequired = process.env.TEST_ACCESS_TOKEN || '';
+
+  // Allowlist helper and health endpoints
+  const isHelperRoute = pathname.startsWith('/api/test-auth') || pathname.startsWith('/api/echo-ip') || pathname.startsWith('/api/health');
+  if (!(enforceProdOnly && isProd) || isHelperRoute) {
+    // Skip enforcement (not prod or helper/health)
+  } else {
+    const headerToken = req.headers.get('x-test-access') || '';
+    const cookieToken = req.cookies.get('test_access')?.value || '';
+    const token = headerToken || cookieToken;
+    if (testAccessRequired && token !== testAccessRequired) {
+      return new NextResponse('Forbidden', {
+        status: 403,
+        headers: { 'x-test-access': 'denied', 'X-Request-Id': requestId },
+      });
+    }
+  }
 
   const isAdminUI  = pathname.startsWith('/admin/');
   const isAdminAPI = pathname.startsWith('/api/admin/');

--- a/src/app/api/echo-ip/route.ts
+++ b/src/app/api/echo-ip/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function GET(req: NextRequest) {
+  const ip = (req as any).ip ?? req.headers.get('x-forwarded-for') ?? 'unknown';
+  return NextResponse.json({ ip });
+}
+
+

--- a/src/app/api/test-auth/route.ts
+++ b/src/app/api/test-auth/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const t = url.searchParams.get('token') || '';
+  const required = process.env.TEST_ACCESS_TOKEN || '';
+
+  if (!required || t !== required) {
+    return new NextResponse('Invalid token', { status: 401 });
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set('test_access', t, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    maxAge: 60 * 60,
+  });
+  return res;
+}


### PR DESCRIPTION
- **middleware(test-access): prod-only gate via x-test-access header or test_access cookie; add /api/test-auth and /api/echo-ip; keep assets/open routes unblocked**
- **middleware: allowlist /api/test-auth and document purpose for prod test gate**
