### PR TITLE
hotfix: provider callback upsert + indexes

### DIFF
--- a/src/app/api/provider/callback/route.ts
+++ b/src/app/api/provider/callback/route.ts
@@ -58,12 +58,12 @@ export async function POST(req: NextRequest) {
     const meta = r.error ? { error: r.error } : (r as any).meta ?? null
 
     if (r.provider_message_id) {
-      // Keep provider_message_id upsert path (idempotent by provider id)
+      // Upsert by provider_message_id; allow update to status/meta when exists
       const { error } = await sb
         .from('delivery_history')
         .upsert(
           [{ provider_message_id: r.provider_message_id, job_id, batch_id, email, status: r.status, meta }],
-          { onConflict: 'provider_message_id', ignoreDuplicates: true }
+          { onConflict: 'provider_message_id' }
         )
       if (error) return jsonErrorWithId(req, 'INSERT_ERROR', error.message, 500)
       continue

--- a/supabase/migrations/20251006_delivery_history_indexes.sql
+++ b/supabase/migrations/20251006_delivery_history_indexes.sql
@@ -1,0 +1,12 @@
+-- Delivery history indexes to support provider callbacks
+
+-- 01) Unique provider_message_id only when present (partial unique index)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_delivery_history_provider_message_id
+ON public.delivery_history (provider_message_id)
+WHERE provider_message_id IS NOT NULL;
+
+-- 02) Lookup accelerator for fallback update path
+CREATE INDEX IF NOT EXISTS ix_delivery_history_job_batch_email
+ON public.delivery_history (job_id, batch_id, email);
+
+


### PR DESCRIPTION
Low-diff hotfix:\n- db: partial unique index on delivery_history.provider_message_id; lookup index on (job_id,batch_id,email)\n- api(callback): upsert on provider_message_id; keep update-first fallback\n\nTests: pnpm vitest run (all green).\n\nPost-deploy smokes (run twice each):\n- With provider_message_id: see docs snippet in PR body\n- Without provider_message_id: see docs snippet in PR body\n\nAcceptance: both return 200 and idempotent; no duplicate rows.